### PR TITLE
added teacher fallback

### DIFF
--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -83,7 +83,7 @@
     {@const atom=today ? today["Atoms"].find(t => t["HourId"] === hour?.["Id"] ?? "#") : null}
     {@const atomNext=today ? today["Atoms"].find(t => t["HourId"] === hourNext?.["Id"] ?? "#") : null}
     {@const subject=$timetableStore["Subjects"].find(s => s["Id"] === (atom?.["SubjectId"] ?? (atomNext?.["SubjectId"] ?? "#")))?.["Abbrev"].toUpperCase() ?? "#"}
-    {@const teacher=$timetablePermanentStore["Teachers"].find(s => s["Id"] === (atom?.["TeacherId"] ?? (atomNext?.["TeacherId"] ?? "#")))?.["Abbrev"] ?? ""}
+    {@const teacher=$timetablePermanentStore["Teachers"].find(s => s["Id"] === (atom?.["TeacherId"] ?? (atomNext?.["TeacherId"] ?? "#")))?.["Abbrev"] ?? $timetableStore["Teachers"].find(s => s["Id"] === (atom?.["TeacherId"] ?? (atomNext?.["TeacherId"] ?? "#")))?.["Abbrev"] ?? ""}
 
     {@const hourH=(hour ? getH(hour["EndTime"]) : getH(hourNext?.["BeginTime"] ?? "00"))}
     {@const hourM=(hour ? getM(hour["EndTime"]) : getM(hourNext?.["BeginTime"] ?? "00"))}

--- a/src/routes/Timetable.svelte
+++ b/src/routes/Timetable.svelte
@@ -166,7 +166,7 @@
                             {@const room=$timetableStore["Rooms"].find(s => s["Id"] === atom["RoomId"])?.["Abbrev"] ?? ""}
                             {@const roomOverride=overrideRooms?.[timetableGroups.find(g => g["id"] === $timetableGroupStore)?.["class"]]}
                             {@const subject=$timetableStore["Subjects"].find(s => s["Id"] === atom["SubjectId"]) ?? null}
-                            {@const teacher=$timetablePermanentStore["Teachers"].find(s => s["Id"] === atom["TeacherId"]) ?? null}
+                            {@const teacher=$timetablePermanentStore["Teachers"].find(s => s["Id"] === atom["TeacherId"]) ?? $timetableStore["Teachers"].find(s => s["Id"] === atom["TeacherId"]) ?? null}
                             <td style="background-color:var(--subject-{subject['Abbrev'].toUpperCase()})" class={past} on:click={modalShow(subject, teacher, atom["Theme"])}>
                                 <div class="flex-atom" style="height:{atomHeight-10}px"> <!--making the div 10px shorter instead of using padding 5px, idk dont ask me tables behave like shit-->
                                     <div class="flex-between">


### PR DESCRIPTION
This pull request includes changes to improve the way teachers are retrieved in the `Countdown.svelte` and `Timetable.svelte` files. The updates ensure that if a teacher is not found in the `timetablePermanentStore`, the code will also search in the `timetableStore`.

Improvements to teacher retrieval:

* [`src/routes/Countdown.svelte`](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL86-R86): Modified the retrieval of the `teacher` constant to search both `timetablePermanentStore` and `timetableStore` for the teacher's abbreviation.
* [`src/routes/Timetable.svelte`](diffhunk://#diff-60ce6e76218a6db2ddd194793e524c3debddbe482d7d9c552305dbf24f570e43L169-R169): Updated the retrieval of the `teacher` constant to check both `timetablePermanentStore` and `timetableStore` for the teacher's information.