### PR TITLE
countdown weekend hotfix

### DIFF
--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -82,10 +82,10 @@
         return hourBegin - time >= 0 && today?.["Atoms"].find(s => s["HourId"] === t["Id"] && s["SubjectId"]) && t["Id"] >= (atomBegin?.["HourId"] ?? 0)
     })}
 
-    {@const atomOriginal=$timetablePermanentStore["Days"][time.getDay() - 1]["Atoms"].find(t => {
+    {@const atomOriginal=$timetablePermanentStore["Days"][time.getDay() - 1]?.["Atoms"].find(t => {
         return t["HourId"] === (hour?.["Id"] ?? "#") && t["CycleIds"]?.includes($timetableStore["Cycles"][0]?.["Id"] ?? overrideWeek(getWeek(time)))
     })}
-    {@const atomOriginalNext=$timetablePermanentStore["Days"][time.getDay() - 1]["Atoms"].find(t => {
+    {@const atomOriginalNext=$timetablePermanentStore["Days"][time.getDay() - 1]?.["Atoms"].find(t => {
         return t["HourId"] === (hourNext?.["Id"] ?? "#") && t["CycleIds"]?.includes($timetableStore["Cycles"][0]?.["Id"] ?? overrideWeek(getWeek(time)))
     })}
 


### PR DESCRIPTION
This pull request includes changes to the `src/routes/Countdown.svelte` file to improve the robustness of the code by adding optional chaining. This ensures that the code handles cases where certain properties might be undefined, preventing potential runtime errors.

Code robustness improvements:

* [`src/routes/Countdown.svelte`](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL85-R88): Added optional chaining to safely access properties within the `atomOriginal` and `atomOriginalNext` constants. This change prevents errors when `["Days"][time.getDay() - 1]` is undefined.