### PR TITLE
double subject OV override fixed && interval safety ig

### DIFF
--- a/src/components/Loading.svelte
+++ b/src/components/Loading.svelte
@@ -10,6 +10,7 @@
     let error = false
 
     onMount(() => {
+        if (interval) clearInterval(interval)
         setInterval(() => {
             error = (new Date().getTime() > start.getTime() + timeToError)
         }, 1000)

--- a/src/routes/Canteen.svelte
+++ b/src/routes/Canteen.svelte
@@ -14,6 +14,7 @@
     onMount(async () => {
         await canteenFetch()
 
+        if (interval) clearInterval(interval)
         interval = setInterval(() => {
             time = new Date()
             if (!$canteenStore) {

--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -48,6 +48,7 @@
 
     onMount(async () => {
         await timetableFetch($timetableGroupStore, 0, "countdown")
+        if (interval) clearInterval(interval)
         interval = setInterval(() => {
             time = new Date()
 

--- a/src/routes/Timetable.svelte
+++ b/src/routes/Timetable.svelte
@@ -5,7 +5,7 @@
     import {LucideArrowBigLeftDash, LucideArrowBigRightDash, LucideMessageSquareText, LucidePencil, LucideTriangleAlert} from "lucide-svelte"
     import Loading from "../components/Loading.svelte"
     import Modal from "../components/Modal.svelte"
-    import {overrideMasters, overrideRooms, overrideWeek} from "../lib/override.js"
+    import {overrideMasters, overrideOV, overrideRooms, overrideWeek} from "../lib/override.js"
     import {getWeek} from "../lib/helper.js"
     import {cOffline, cRefresh} from "../lib/const.js"
 
@@ -74,6 +74,8 @@
     onMount(async () => {
         page = 0
         await timetableFetch($timetableGroupStore, page, "timetable")
+
+        if (interval) clearInterval(interval)
         interval = setInterval(() => {
             time = getTime()
 
@@ -150,7 +152,9 @@
                         return t["HourId"] === hour["Id"] && t["CycleIds"]?.includes($timetableStore["Cycles"][0]?.["Id"] ?? overrideWeek(pageWeek))
                     })}
                     {@const subjectOriginal=($timetablePermanentStore["Subjects"].find(s => s["Id"] === (atomOriginal?.["SubjectId"] ?? "#")) ?? null)}
-                    {@const atom=(day?.["Atoms"].find(t => t["HourId"] === hour["Id"] && (t["Change"] === null || t["SubjectId"] !== (atomOriginal?.["SubjectId"] ?? "#") || t["TeacherId"] !== (atomOriginal?.["TeacherId"] ?? "#"))) ?? null)}
+
+                    <!--atom duplicate edge case: there must not be change or subject OV, or there must be a real change => subject or teacher is changed-->
+                    {@const atom=(day?.["Atoms"].find(t => t["HourId"] === hour["Id"] && (t["Change"] === null || t["SubjectId"] === overrideOV["Atoms"][0]["SubjectId"] || t["SubjectId"] !== (atomOriginal?.["SubjectId"] ?? "#") || t["TeacherId"] !== (atomOriginal?.["TeacherId"] ?? "#"))) ?? null)}
                     {#if day["DayType"] !== "WorkDay" && subjectOriginal} <!--special day-->
                         <td class={"subject-removed "+past} on:click={modalShow(day["DayType"], null, day["DayDescription"])}>
                             <span></span>


### PR DESCRIPTION
This pull request includes several changes to improve the handling of intervals and to address an edge case in the timetable logic. The most important changes include clearing intervals before setting new ones in various components and modifying the timetable logic to handle a specific edge case.

Improvements to interval handling:

* [`src/components/Loading.svelte`](diffhunk://#diff-28dc6d42ee759969313127d07cb7af8c5e99bfd2271205372a162c697a29f983R13): Added a check to clear existing intervals before setting a new one in the `onMount` lifecycle function.
* [`src/routes/Canteen.svelte`](diffhunk://#diff-7774b078b44a80930e163a9bbc7bde160c0010ad303fbf266766d7fe470b9b7cR17): Added a check to clear existing intervals before setting a new one in the `onMount` lifecycle function.
* [`src/routes/Countdown.svelte`](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eR51): Added a check to clear existing intervals before setting a new one in the `onMount` lifecycle function.
* [`src/routes/Timetable.svelte`](diffhunk://#diff-60ce6e76218a6db2ddd194793e524c3debddbe482d7d9c552305dbf24f570e43R77-R78): Added a check to clear existing intervals before setting a new one in the `onMount` lifecycle function.

Timetable logic enhancement:

* [`src/routes/Timetable.svelte`](diffhunk://#diff-60ce6e76218a6db2ddd194793e524c3debddbe482d7d9c552305dbf24f570e43L153-R157): Modified the timetable logic to handle an edge case where there must not be a change or the subject must be overridden, or there must be a real change (subject or teacher is changed).

Additionally, there was a minor import change in `src/routes/Timetable.svelte`:

* [`src/routes/Timetable.svelte`](diffhunk://#diff-60ce6e76218a6db2ddd194793e524c3debddbe482d7d9c552305dbf24f570e43L8-R8): Changed the import from `overrideMasters, overrideRooms, overrideWeek` to include `overrideOV`.