### PR TITLE
modal close button hotfix

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -191,7 +191,6 @@
         display: flex;
         justify-content: center;
         width: inherit;
-        will-change: opacity;
     }
 
     footer :global(svg) {
@@ -199,7 +198,6 @@
         stroke: var(--white);
         margin: 13px 0;
         display: block;
-        will-change: transform, stroke;
     }
 
     footer :global(a[data-active="true"] svg) {

--- a/src/components/Loading.svelte
+++ b/src/components/Loading.svelte
@@ -37,7 +37,7 @@
         display: flex;
         flex-direction: column;
         gap: 10px;
-        animation: var(--animation-blend);
+        animation: var(--animation-fade-in);
     }
 
     #loading :global(svg) {

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -10,7 +10,7 @@
     <div class="dialog-block">
         <header>
             <h3 style="color:var(--silver)">{title}</h3>
-            <button onclick={modal.close()}>
+            <button onclick={() => modal.close()}>
                 <LucideX/>
             </button>
         </header>

--- a/src/index.html
+++ b/src/index.html
@@ -45,9 +45,9 @@
             --brand-milky: linear-gradient(145deg, rgba(223, 193, 246, 0.4) 0%, rgba(129, 110, 164, 0.4) 100%);
             --border: 5px;
             --transition: 0.1s;
-            --hover: opacity(0.4);
+            --hover: 0.4;
             --animation-rotate: rotate 1.5s cubic-bezier(.79, .14, .15, .86) infinite;
-            --animation-blend: blend 1s cubic-bezier(.6, -0.28, .74, .05) 1;
+            --animation-fade-in: fade-in 1s cubic-bezier(.6, -0.28, .74, .05) 1;
             --animation-scale: 50ms reverse scale;
         }
 
@@ -182,20 +182,28 @@
             font-weight: bold;
         }
 
-        a, button {
-            transition: var(--transition) all linear;
+        a svg, button svg {
+            will-change: transform, opacity, stroke;
+            transition: var(--transition) opacity linear;
         }
 
         button:disabled,
         button[disabled] {
-            filter: var(--hover);
             cursor: default !important;
+        }
+
+        button:disabled svg,
+        button[disabled] svg {
+            opacity: var(--hover);
         }
 
         @media (hover: hover) and (pointer: fine) {
             a:hover, button:hover {
                 cursor: pointer;
-                filter: var(--hover);
+            }
+
+            a:hover svg, button:hover svg {
+                opacity: var(--hover);
             }
         }
 
@@ -210,7 +218,7 @@
             display: none;
             height: 100svh;
             width: 100%;
-            animation: var(--animation-blend);
+            animation: var(--animation-fade-in);
         }
 
         #init-loading div {
@@ -241,15 +249,6 @@
         @keyframes rotate {
             100% {
                 transform: rotate(360deg);
-            }
-        }
-
-        @keyframes blend {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
             }
         }
 

--- a/src/routes/Timetable.svelte
+++ b/src/routes/Timetable.svelte
@@ -277,7 +277,6 @@
         padding: 0;
         width: 40px;
         height: 40px;
-        will-change: transform, opacity;
     }
 
     nav button:active :global(svg) {


### PR DESCRIPTION
This pull request includes several changes to improve the styling and animation effects across various components in the Svelte application. The most important changes include modifying animation styles, updating button click handlers, and refining hover and disabled states for buttons.

### Animation and Styling Updates:

* [`src/components/Loading.svelte`](diffhunk://#diff-28dc6d42ee759969313127d07cb7af8c5e99bfd2271205372a162c697a29f983L40-R40): Changed the animation from `--animation-blend` to `--animation-fade-in` for a smoother fade-in effect.
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL48-R50): Updated the hover effect to use a numerical value instead of `opacity(0.4)` and changed the animation from `--animation-blend` to `--animation-fade-in`. Removed the `@keyframes blend` definition as it is no longer needed. [[1]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL48-R50) [[2]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL213-R221) [[3]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL247-L255)

### Button and SVG Handling:

* [`src/components/Modal.svelte`](diffhunk://#diff-44cecc6378a3c6555432bfb2e0f441cc925879cb1ca5ebe0802567402914688eL13-R13): Modified the button click handler to use an arrow function for consistency and clarity.
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL185-R206): Updated the styles for `a svg` and `button svg` to include `will-change` properties and adjusted the transition for better performance. Improved the handling of disabled buttons and hover states for SVG elements.

### Removal of Unnecessary Properties:

* [`src/App.svelte`](diffhunk://#diff-d68daa8b73cec8e4419759802bbd91e9f87f8ee02f25cdb1d12582ef6de848dbL194-L202): Removed `will-change` properties from elements where they were not necessary, simplifying the CSS. [[1]](diffhunk://#diff-d68daa8b73cec8e4419759802bbd91e9f87f8ee02f25cdb1d12582ef6de848dbL194-L202) [[2]](diffhunk://#diff-60ce6e76218a6db2ddd194793e524c3debddbe482d7d9c552305dbf24f570e43L280)