### PR TITLE
Modal line-break hotfix

### DIFF
--- a/src/routes/Timetable.svelte
+++ b/src/routes/Timetable.svelte
@@ -135,7 +135,7 @@
         {/if}
         {#if modalTheme !== ""}
             <div style="height:10px"></div>
-            <h3 style="color:var(--silver)">{modalTheme}</h3>
+            <h3 style="color:var(--silver);white-space:pre-line">{modalTheme}</h3>
         {/if}
     </Modal>
     <table>


### PR DESCRIPTION
This pull request includes a small change to the `src/routes/Timetable.svelte` file. The change ensures that the `modalTheme` text respects line breaks by adding the `white-space: pre-line` style to the `<h3>` element.