### PR TITLE
fixed ordering button width

### DIFF
--- a/src/routes/Canteen.svelte
+++ b/src/routes/Canteen.svelte
@@ -117,7 +117,7 @@
 	}
 
 	#canteen-button {
-		width: calc(100% - 20px);
+		width: calc(min(540px, 100%) - 20px);
 		height: 40px;
 		margin: 10px;
 		bottom: 50px;


### PR DESCRIPTION
This pull request includes a minor improvement to the styling of the `#canteen-button` element in the `src/routes/Canteen.svelte` file. The change ensures that the button's width is capped at a maximum of 540px, while still adapting to smaller screen sizes.

* [`src/routes/Canteen.svelte`](diffhunk://#diff-7774b078b44a80930e163a9bbc7bde160c0010ad303fbf266766d7fe470b9b7cL120-R120): Updated the `#canteen-button` width calculation to use `calc(min(540px, 100%) - 20px)` for better responsiveness.