### PR TITLE
class numbers incremented

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
       "name": "pain",
       "dependencies": {
         "@dvcol/svelte-simple-router": "2.7.2",
-        "browserslist": "^4.25.3",
+        "browserslist": "^4.25.4",
         "fast-blurhash": "^1.1.4",
         "lightningcss": "^1.30.1",
-        "lucide-svelte": "^0.541.0",
+        "lucide-svelte": "^0.542.0",
         "path": "^0.12.7",
         "vite-plugin-minify": "^2.1.0",
         "vite-plugin-pwa": "^1.0.3",
@@ -17,8 +17,8 @@
         "@sveltejs/vite-plugin-svelte": "^6.1.3",
         "@umami/node": "^0.4.0",
         "sparticles": "^1.3.1",
-        "svelte": "^5.38.3",
-        "vite": "^7.1.3",
+        "svelte": "^5.38.6",
+        "vite": "^7.1.4",
       },
     },
   },
@@ -331,7 +331,7 @@
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.1", "", { "dependencies": { "debug": "^4.4.1" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA=="],
 
-    "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/html-minifier-terser": ["@types/html-minifier-terser@7.0.2", "", {}, "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA=="],
 
@@ -373,7 +373,7 @@
 
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
-    "browserslist": ["browserslist@4.25.3", "", { "dependencies": { "caniuse-lite": "^1.0.30001735", "electron-to-chromium": "^1.5.204", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ=="],
+    "browserslist": ["browserslist@4.25.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001737", "electron-to-chromium": "^1.5.211", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -431,7 +431,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.209", "", {}, "sha512-Xoz0uMrim9ZETCQt8UgM5FxQF9+imA7PBpokoGcZloA1uw2LeHzTlip5cb5KOAsXZLjh/moN2vReN3ZjJmjI9A=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.211", "", {}, "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -637,7 +637,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-svelte": ["lucide-svelte@0.541.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-Jk+LiOYDl62R/0nWkG1s5XL2k6LHmPq3wUfiJ6qtBhb8jGefB4PU10x5HJrAihwaKqVc2vH5wjKMELGjHJenEQ=="],
+    "lucide-svelte": ["lucide-svelte@0.542.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-KxqJycY4EWaGy1zk/7sqEcf48j4YaP9zEujYczzrsw5j9b9b5pjAJ1qGFKZvD7T6xz9reSYAfUAd6Bz62TdqGw=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
@@ -765,7 +765,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.38.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-ldbPzKdjUy7IALMBn15jzBM/TNxdXMxKeQZ538zzdABUjLg7e7/OIwnlaMQ+OR6s91W7DbDmJYjxHThHH7r9xA=="],
+    "svelte": ["svelte@5.38.6", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-ltBPlkvqk3bgCK7/N323atUpP3O3Y+DrGV4dcULrsSn4fZaaNnOmdplNznwfdWclAgvSr5rxjtzn/zJhRm6TKg=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 
@@ -811,7 +811,7 @@
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
-    "vite": ["vite@7.1.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw=="],
+    "vite": ["vite@7.1.4", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw=="],
 
     "vite-plugin-minify": ["vite-plugin-minify@2.1.0", "", { "dependencies": { "@types/html-minifier-terser": "^7.0.2", "html-minifier-terser": "^7.2.0" }, "peerDependencies": { "vite": ">=5" } }, "sha512-h+Ae0WX0mvrWM4GhE6JX2NmxlDuZRv4AgcTHFqfbSyPwS+OdlOM692AQrK0eO8lDEh7gYLjG3EHovKvtrNQDvA=="],
 
@@ -899,7 +899,7 @@
 
     "html-minifier-terser/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
-    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+    "is-reference/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -915,9 +915,15 @@
 
     "@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.155", "", {}, "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng=="],
 
+    "@dvcol/svelte-simple-router/svelte/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+
     "@dvcol/svelte-simple-router/svelte/esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
 
+    "@dvcol/svelte-utils/svelte/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+
     "@dvcol/svelte-utils/svelte/esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
+
+    "@rollup/plugin-node-resolve/@rollup/pluginutils/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
 		"@sveltejs/vite-plugin-svelte": "^6.1.3",
 		"@umami/node": "^0.4.0",
 		"sparticles": "^1.3.1",
-		"svelte": "^5.38.3",
-		"vite": "^7.1.3"
+		"svelte": "^5.38.6",
+		"vite": "^7.1.4"
 	},
 	"dependencies": {
 		"@dvcol/svelte-simple-router": "2.7.2",
-		"browserslist": "^4.25.3",
+		"browserslist": "^4.25.4",
 		"fast-blurhash": "^1.1.4",
 		"lightningcss": "^1.30.1",
-		"lucide-svelte": "^0.541.0",
+		"lucide-svelte": "^0.542.0",
 		"path": "^0.12.7",
 		"vite-plugin-minify": "^2.1.0",
 		"vite-plugin-pwa": "^1.0.3"

--- a/src/index.html
+++ b/src/index.html
@@ -144,7 +144,7 @@
 			min-height: 13px;
 			line-height: 13px;
 			color: var(--pink);
-			font-family: monospace, monospace;
+			font-family: RobotoMono, monospace;
 			font-weight: normal;
 		}
 
@@ -153,7 +153,7 @@
 			min-height: 13px;
 			line-height: 13px;
 			color: var(--snow);
-			font-family: monospace, monospace;
+			font-family: RobotoMono, monospace;
 			font-weight: normal;
 			line-break: anywhere;
 			border: 1px var(--gray) solid;

--- a/src/lib/override.js
+++ b/src/lib/override.js
@@ -11,11 +11,18 @@ export const overrideOV = {
 }
 
 export const overrideRooms = {
-	R3: {
+	/*R3: {
 		ignore: ["TV", "CAD", "AJ"],
 		rooms: [
 			[4, 4, 0, 0, 0], // odd
 			[1, 1, 1, 2, 4], // even
+		],
+	},*/
+	R4: {
+		ignore: ["TV"],
+		rooms: [
+			[0, 0, 0, 0, 0], // odd
+			[0, 0, 0, 0, 0], // even
 		],
 	},
 }
@@ -48,7 +55,7 @@ export const overrideCanteen = {
 
 export const overrideOVGroup = {
 	"764": [[null, null, null, null, null], [null, null, null, null, null]],
-	"ZGY21K": [ // R3-EM3-OV4
+	/*"ZGY21K": [ // R3-EM3-OV4
 		[null, null, "UV02Z", "UV02Z", "UX03D"], // odd
 		[null, null, null, null, null], // even 4->1->2->3
 	],
@@ -59,7 +66,7 @@ export const overrideOVGroup = {
 	"RGW1X6": [ // R3-EM1-OV2
 		[null, null, "UJ01Z", "UX03D", "U0014"], // odd
 		[null, null, null, null, null], // even 2->3->4->1
-	],
+	],*/
 }
 
 export const overrideWeek = week => {

--- a/src/lib/var.js
+++ b/src/lib/var.js
@@ -1,11 +1,11 @@
 import { writable } from "svelte/store"
 
 export const source = {
-	"gymnp.cz": [{ id: "764", name: "KVINTA", class: "KVINTA", src: "am" }],
-	"sssenp.cz": [{ id: "ZGY21K", name: "R3-EM3-OV4", class: "R3", src: "sa" }, { id: "ZGW1WS", name: "R3-EM2-OV3", class: "R3", src: "dk" }, {
+	"gymnp.cz": [{ id: "764", name: "SEXTA", class: "SEXTA", src: "am" }],
+	"sssenp.cz": [{ id: "ZGY21K", name: "R4-OV2", class: "R4", src: "sa" }, { id: "ZGW1WS", name: "R3-OV3", class: "R4", src: "dk" }, {
 		id: "RGW1X6",
-		name: "R3-EM1-OV2",
-		class: "R3",
+		name: "R4-OV2",
+		class: "R4",
 		src: "af",
 	}],
 }

--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -1,14 +1,14 @@
 <script>
-	import { onDestroy, onMount } from "svelte"
+	import {onDestroy, onMount} from "svelte"
 	import Banner from "../components/Banner.svelte"
 	import Loading from "../components/Loading.svelte"
-	import { cOffline, cRefresh } from "../lib/const.js"
-	import { formatAddZero, formatTime } from "../lib/format.js"
-	import { getWeek } from "../lib/helper.js"
-	import { overrideRooms, overrideWeek } from "../lib/override.js"
-	import { timetableCountdownStore, timetableFetch, timetablePermanentStore } from "../lib/timetable.js"
-	import { source, sourceGroupStore, sourceSchoolStore } from "../lib/var.js"
-	import { update } from "../main.js"
+	import {cOffline, cRefresh} from "../lib/const.js"
+	import {formatAddZero, formatTime} from "../lib/format.js"
+	import {getWeek} from "../lib/helper.js"
+	import {overrideRooms, overrideWeek} from "../lib/override.js"
+	import {timetableCountdownStore, timetableFetch, timetablePermanentStore} from "../lib/timetable.js"
+	import {source, sourceGroupStore, sourceSchoolStore} from "../lib/var.js"
+	import {update} from "../main.js"
 
 	let animate = $state(false)
 	let time = $state(new Date())
@@ -201,13 +201,13 @@
 	#countdown-clock {
 		display: flex;
 		justify-content: center;
-		user-select: none;
-		font-family: RobotoMono, monospace;
 	}
 
 	#countdown-clock * {
 		animation: var(--animation-scale);
 		animation-duration: 0s;
+		user-select: none;
+		font-family: RobotoMono, monospace;
 	}
 
 	#countdown-clock[data-animate="true"] * {


### PR DESCRIPTION
This pull request includes several updates focused on dependency upgrades, UI font improvements, and reworking some override and source data for rooms and groups. The most significant changes are summarized below:

**Dependency Upgrades:**

* Updated several dependencies in `package.json`, including `svelte`, `vite`, `browserslist`, and `lucide-svelte`, to their latest patch versions for improved stability and compatibility.

**UI and Styling Improvements:**

* Changed the font family for code and countdown elements from the generic `monospace` to `RobotoMono, monospace` in both `src/index.html` and `src/routes/Countdown.svelte` for a more consistent and modern appearance. [[1]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL147-R147) [[2]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL156-R156) [[3]](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL204-R210)

**Override and Source Data Updates:**

* Commented out the `R3` room override and added a new `R4` override in `src/lib/override.js`, reflecting changes in room assignments.
* Commented out the `ZGY21K` group override in `overrideOVGroup`, indicating that this mapping is no longer active. [[1]](diffhunk://#diff-fac9200b0b7e684c0573c5074c43134bcd4030913c388cc12d0976049c871055L51-R58) [[2]](diffhunk://#diff-fac9200b0b7e684c0573c5074c43134bcd4030913c388cc12d0976049c871055L62-R69)
* Updated the `source` object in `src/lib/var.js` to reflect new class and group names, changing references from "R3" to "R4" and updating group names accordingly.