### PR TITLE
fixed sssenp.cz group names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "vite-plugin-pwa": "^1.0.3",
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^6.1.3",
+        "@sveltejs/vite-plugin-svelte": "^6.1.4",
         "@umami/node": "^0.4.0",
         "sparticles": "^1.3.1",
         "svelte": "^5.38.6",
@@ -327,7 +327,7 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.5", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ=="],
 
-    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.1.3", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-3pppgIeIZs6nrQLazzKcdnTJ2IWiui/UucEPXKyFG35TKaHQrfkWBnv6hyJcLxFuR90t+LaoecrqTs8rJKWfSQ=="],
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.1.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-4jfkfvsGI+U2OhHX8OPCKtMCf7g7ledXhs3E6UcA4EY0jQWsiVbe83pTAHp9XTifzYNOiD4AJieJUsI0qqxsbw=="],
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.1", "", { "dependencies": { "debug": "^4.4.1" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA=="],
 
@@ -598,8 +598,6 @@
     "jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
-
-    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^6.1.3",
+		"@sveltejs/vite-plugin-svelte": "^6.1.4",
 		"@umami/node": "^0.4.0",
 		"sparticles": "^1.3.1",
 		"svelte": "^5.38.6",

--- a/src/lib/var.js
+++ b/src/lib/var.js
@@ -2,9 +2,9 @@ import {writable} from "svelte/store"
 
 export const source = {
 	"gymnp.cz": [{ id: "764", name: "SEXTA", class: "SEXTA", src: "am" }],
-	"sssenp.cz": [{ id: "ZGY21K", name: "R4-OV1", class: "R4", src: "sa" }, { id: "RGW1X6", name: "R4-OV2", class: "R4", src: "af" }, {
+	"sssenp.cz": [{ id: "ZGY21K", name: "R4-OV1-A1-EM1", class: "R4", src: "sa" }, { id: "RGW1X6", name: "R4-OV2-A1-EM1", class: "R4", src: "af" }, {
 		id: "ZGW1WS",
-		name: "R3-OV3",
+		name: "R4-OV3-A2-EM2",
 		class: "R4",
 		src: "dk",
 	}],

--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -1,14 +1,14 @@
 <script>
-	import { onDestroy, onMount } from "svelte"
+	import {onDestroy, onMount} from "svelte"
 	import Banner from "../components/Banner.svelte"
 	import Loading from "../components/Loading.svelte"
-	import { cOffline, cRefresh } from "../lib/const.js"
-	import { formatAddZero, formatTime } from "../lib/format.js"
-	import { getWeek } from "../lib/helper.js"
-	import { overrideMasters, overrideRooms, overrideWeek } from "../lib/override.js"
-	import { timetableCountdownStore, timetableFetch, timetablePermanentStore } from "../lib/timetable.js"
-	import { source, sourceGroupStore, sourceSchoolStore } from "../lib/var.js"
-	import { update } from "../main.js"
+	import {cOffline, cRefresh} from "../lib/const.js"
+	import {formatAddZero, formatTime} from "../lib/format.js"
+	import {getWeek} from "../lib/helper.js"
+	import {overrideMasters, overrideRooms, overrideWeek} from "../lib/override.js"
+	import {timetableCountdownStore, timetableFetch, timetablePermanentStore} from "../lib/timetable.js"
+	import {source, sourceGroupStore, sourceSchoolStore} from "../lib/var.js"
+	import {update} from "../main.js"
 
 	let animate = $state(false)
 	let time = $state(new Date())
@@ -105,7 +105,7 @@
 					{#key hourH}
 						<h1 style="will-change: transform">{hourH}</h1>
 					{/key}
-					<h1 style="color: var(--silver); font-size: 65px; line-height: 65px; min-height: 65px; letter-spacing: -5px; text-indent: -5px">:</h1>
+					<h1 class="countdown-clock-colon">:</h1>
 				{/if}
 				{#if subject !== "#"}
 					{#key hourM}
@@ -114,7 +114,7 @@
 				{:else}
 					<h1>00</h1>
 				{/if}
-				<h1 style="color: var(--silver); font-size: 65px; line-height: 65px; min-height: 65px; letter-spacing: -5px; text-indent: -5px">:</h1>
+				<h1 class="countdown-clock-colon">:</h1>
 				{#if subject !== "#"}
 					{#key hourS}
 						<h1 style="will-change: transform">{hourS}</h1>
@@ -209,6 +209,16 @@
 		animation-duration: 0s;
 		user-select: none;
 		font-family: RobotoMono, monospace;
+	}
+
+	/*i dont want to talk about this xd*/
+	.countdown-clock-colon {
+		color: var(--silver);
+		font-size: 60px;
+		line-height: 60px;
+		min-height: 60px;
+		letter-spacing: -5px;
+		text-indent: -6px;
 	}
 
 	#countdown-clock[data-animate="true"] * {


### PR DESCRIPTION
This pull request introduces a minor dependency update, updates some data in a Svelte store, and refactors the styling of the countdown clock colons in the `Countdown.svelte` component. The main themes are dependency management, data consistency, and CSS refactoring for maintainability.

**Dependency update:**
* Upgraded `@sveltejs/vite-plugin-svelte` from version `6.1.3` to `6.1.4` in `package.json` to keep development dependencies current.

**Data consistency:**
* Updated the entries for `"sssenp.cz"` in the `source` object in `src/lib/var.js` to use more descriptive `name` fields (e.g., `"R4-OV1-A1-EM1"` instead of `"R4-OV1"`) and updated one entry's name from `"R3-OV3"` to `"R4-OV3-A2-EM2"`.

**UI/CSS refactoring:**
* In `src/routes/Countdown.svelte`, replaced inline styles on the colon (`:`) elements with a new CSS class `countdown-clock-colon` for improved maintainability. [[1]](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL108-R108) [[2]](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL117-R117)
* Added the `.countdown-clock-colon` CSS class definition to the same file, centralizing the styling for the colons in the countdown clock.