### PR TITLE
small timetable tweaks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@umami/node": "^0.4.0",
         "sparticles": "^1.3.1",
         "svelte": "^5.38.7",
-        "vite": "^7.1.4",
+        "vite": "^7.1.5",
       },
     },
   },
@@ -771,7 +771,7 @@
 
     "terser": ["terser@5.39.2", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.14.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -809,7 +809,7 @@
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
-    "vite": ["vite@7.1.4", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw=="],
+    "vite": ["vite@7.1.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ=="],
 
     "vite-plugin-minify": ["vite-plugin-minify@2.1.0", "", { "dependencies": { "@types/html-minifier-terser": "^7.0.2", "html-minifier-terser": "^7.2.0" }, "peerDependencies": { "vite": ">=5" } }, "sha512-h+Ae0WX0mvrWM4GhE6JX2NmxlDuZRv4AgcTHFqfbSyPwS+OdlOM692AQrK0eO8lDEh7gYLjG3EHovKvtrNQDvA=="],
 
@@ -901,9 +901,7 @@
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
-    "tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+    "vite-plugin-pwa/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
@@ -932,5 +930,9 @@
     "core-js-compat/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.155", "", {}, "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "vite-plugin-pwa/tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
+
+    "vite-plugin-pwa/tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@umami/node": "^0.4.0",
 		"sparticles": "^1.3.1",
 		"svelte": "^5.38.7",
-		"vite": "^7.1.4"
+		"vite": "^7.1.5"
 	},
 	"dependencies": {
 		"@dvcol/svelte-simple-router": "2.7.2",

--- a/src/lib/override.js
+++ b/src/lib/override.js
@@ -117,7 +117,7 @@ export const overrideRooms = {
 	ZGY21K: {
 		rooms: [
 			[
-				["VT2", "4", "4", "8", "8", "1", "1", "VT2", "VT2"],
+				["VT2", "4", "4", "8", "8", "3", "3", "VT2", "VT2"],
 				["EM", "EM", "3", "VT1", "VT1", "12", "VT2", "EM", "EM"],
 				[null, "4", "4", "12", "2", "2", "VT2", "VT2", null],
 				[null, null, null, null, null, null, null, null, null], // OV
@@ -135,7 +135,7 @@ export const overrideRooms = {
 	RGW1X6: {
 		rooms: [
 			[
-				["VT2", "4", "4", "8", "8", "1", "1", "VT2", "VT2"],
+				["VT2", "4", "4", "8", "8", "3", "3", "VT2", "VT2"],
 				["EM", "EM", "3", "VT1", "VT1", "12", "VT2", "EM", "EM"],
 				[null, "4", "4", "12", "2", "2", "VT2", "VT2", null],
 				[null, null, null, null, null, null, null, null, null], // OV
@@ -153,7 +153,7 @@ export const overrideRooms = {
 	ZGW1WS: {
 		rooms: [
 			[
-				["VT2", "11", "11", "8", "8", "1", "1", "VT2", "VT2"],
+				["VT2", "11", "11", "8", "8", "3", "3", "VT2", "VT2"],
 				["EM", "EM", "3", "VT1", "VT1", "VT2", "VT2", "EM", "EM"],
 				[null, "4", "4", "12", "2", "2", "VT2", "VT2", null],
 				[null, null, null, null, null, null, null, null, null], // OV

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -1,7 +1,7 @@
 <script>
-	import {preload} from "../lib/preload.js"
-	import {umami} from "../lib/umami.js"
-	import {source, sourceGroupStore, sourceSchoolStore} from "../lib/var.js"
+	import { preload } from "../lib/preload.js"
+	import { umami } from "../lib/umami.js"
+	import { source, sourceGroupStore, sourceSchoolStore } from "../lib/var.js"
 
 	const setSchool = () => {
 		localStorage.setItem("school", $sourceSchoolStore.toString())
@@ -40,11 +40,11 @@
 		</select>
 	</div>
 	<div style="margin: 60px 0 0 0">
-		<span>Zde může být i tvoje třída/skupina stačí když mi pošleš</span>
+		<span>Zde může být i tvoje třída/skupina, stačí, když mi pošleš</span>
 		<span style="color: var(--pink)">refresh-token</span>
-		<span>z tvého bakaláře na discord @czqery</span>
+		<span>z tvého bakaláře na discord @czqery.</span>
 		<br>
-		<span>Zadej tento příkaz do CMD a bakalář ti token vygeneruje</span>
+		<span>Zadej tento příkaz do CMD, a bakalář ti token vygeneruje.</span>
 	</div>
 
 	<code>curl -d "grant_type=password&client_id=ANDR&username=<strong>jméno</strong>&password=<strong>heslo</strong>&scope=bakalari_api+offline_access+timetable_widget" https://sssenp.bakalari.cz/api/login</code>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -1,7 +1,7 @@
 <script>
-	import { preload } from "../lib/preload.js"
-	import { umami } from "../lib/umami.js"
-	import { source, sourceGroupStore, sourceSchoolStore } from "../lib/var.js"
+	import {preload} from "../lib/preload.js"
+	import {umami} from "../lib/umami.js"
+	import {source, sourceGroupStore, sourceSchoolStore} from "../lib/var.js"
 
 	const setSchool = () => {
 		localStorage.setItem("school", $sourceSchoolStore.toString())
@@ -43,6 +43,8 @@
 		<span>Zde může být i tvoje třída/skupina stačí když mi pošleš</span>
 		<span style="color: var(--pink)">refresh-token</span>
 		<span>z tvého bakaláře na discord @czqery</span>
+		<br>
+		<span>Zadej tento příkaz do CMD a bakalář ti token vygeneruje</span>
 	</div>
 
 	<code>curl -d "grant_type=password&client_id=ANDR&username=<strong>jméno</strong>&password=<strong>heslo</strong>&scope=bakalari_api+offline_access+timetable_widget" https://sssenp.bakalari.cz/api/login</code>

--- a/src/routes/Timetable.svelte
+++ b/src/routes/Timetable.svelte
@@ -1,15 +1,15 @@
 <script>
-	import {LucideArrowBigLeftDash, LucideArrowBigRightDash, LucideCookingPot, LucideMessageSquareText, LucidePencil, LucideTriangleAlert} from "lucide-svelte"
-	import {onDestroy, onMount} from "svelte"
+	import { LucideArrowBigLeftDash, LucideArrowBigRightDash, LucideCookingPot, LucideMessageSquareText, LucidePencil, LucideTriangleAlert } from "lucide-svelte"
+	import { onDestroy, onMount } from "svelte"
 	import Loading from "../components/Loading.svelte"
 	import Modal from "../components/Modal.svelte"
-	import {canteenStore} from "../lib/canteen.js"
-	import {cOffline, cRefresh} from "../lib/const.js"
-	import {formatCapitalize, formatOrdinalNumber, formatTime} from "../lib/format.js"
-	import {getWeek} from "../lib/helper.js"
-	import {overrideMasters, overrideOV, overrideRooms, overrideWeek} from "../lib/override.js"
-	import {timetableFetch, timetablePageStore, timetablePermanentStore, timetableStore} from "../lib/timetable.js"
-	import {sourceGroupStore} from "../lib/var.js"
+	import { canteenStore } from "../lib/canteen.js"
+	import { cOffline, cRefresh } from "../lib/const.js"
+	import { formatCapitalize, formatOrdinalNumber, formatTime } from "../lib/format.js"
+	import { getWeek } from "../lib/helper.js"
+	import { overrideMasters, overrideOV, overrideRooms, overrideWeek } from "../lib/override.js"
+	import { timetableFetch, timetablePageStore, timetablePermanentStore, timetableStore } from "../lib/timetable.js"
+	import { sourceGroupStore } from "../lib/var.js"
 
 	const hours = 9 // 0-8
 	// const hours = 10 // 0-9
@@ -124,6 +124,7 @@
 	</nav>
 {/if}
 {#if $timetableStore && $timetablePermanentStore && $timetablePermanentStore["Hours"]}
+	{@const pageHours = $timetablePermanentStore["Hours"].slice(0, hours)}
 	{@const pageWeek = getWeek(getNewDateTime(5))}
 	<Modal bind:modal title="Tuition details">
 		{#if modalSubjectColor === "FREE"}
@@ -139,7 +140,7 @@
 			<h4 style="color: var(--silver); white-space: pre-line">{modalTheme}</h4>
 		{/if}
 	</Modal>
-	<table style:--corner={cornerHeight + "px"} style:--hours={hours}>
+	<table style:--corner={cornerHeight + "px"} style:--hours={pageHours.length}>
 		<thead>
 			<tr>
 				<th class="slim" bind:offsetHeight={cornerHeight}>
@@ -164,7 +165,7 @@
 			</tr>
 		</thead>
 		<tbody>
-			{#each $timetableStore["Hours"].slice(0, hours) as hour, i}
+			{#each pageHours as hour, i}
 				<tr class="atom">
 					<th class="slim">
 						<h2>{hour["Caption"]}</h2>


### PR DESCRIPTION
This pull request introduces a minor dependency update and several improvements to the timetable and settings pages, as well as updates to room overrides. The most important changes are grouped below:

**Dependency Update:**

* Upgraded the `vite` dependency in `package.json` from version `7.1.4` to `7.1.5`, ensuring the project uses the latest bug fixes and improvements.

**Timetable Rendering Improvements:**

* Defined a new constant `pageHours` in `Timetable.svelte` to slice the hours array, improving clarity and maintainability in timetable rendering.
* Updated the timetable table’s `--hours` style property to use the length of `pageHours`, ensuring correct rendering of hour rows.
* Refactored the timetable row rendering to use `pageHours` instead of slicing the store directly, making the code more readable and consistent.

**Room Overrides Update:**

* Changed the room override values for `ZGY21K`, `RGW1X6`, and `ZGW1WS` in `override.js`, replacing `"1", "1"` with `"3", "3"` in the first row of each group, likely reflecting updated room assignments. [[1]](diffhunk://#diff-fac9200b0b7e684c0573c5074c43134bcd4030913c388cc12d0976049c871055L120-R120) [[2]](diffhunk://#diff-fac9200b0b7e684c0573c5074c43134bcd4030913c388cc12d0976049c871055L138-R138) [[3]](diffhunk://#diff-fac9200b0b7e684c0573c5074c43134bcd4030913c388cc12d0976049c871055L156-R156)

**Settings Page Enhancement:**

* Improved the instructional text in `Settings.svelte` for generating a refresh token, adding clarification and a sample command for users to follow.