### PR TITLE
idk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,16 +8,16 @@
         "browserslist": "^4.25.4",
         "fast-blurhash": "^1.1.4",
         "lightningcss": "^1.30.1",
-        "lucide-svelte": "^0.542.0",
+        "lucide-svelte": "^0.543.0",
         "path": "^0.12.7",
         "vite-plugin-minify": "^2.1.0",
         "vite-plugin-pwa": "^1.0.3",
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^6.1.4",
+        "@sveltejs/vite-plugin-svelte": "^6.2.0",
         "@umami/node": "^0.4.0",
         "sparticles": "^1.3.1",
-        "svelte": "^5.38.7",
+        "svelte": "^5.38.8",
         "vite": "^7.1.5",
       },
     },
@@ -327,7 +327,7 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.5", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ=="],
 
-    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.1.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-4jfkfvsGI+U2OhHX8OPCKtMCf7g7ledXhs3E6UcA4EY0jQWsiVbe83pTAHp9XTifzYNOiD4AJieJUsI0qqxsbw=="],
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.0", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-nJsV36+o7rZUDlrnSduMNl11+RoDE1cKqOI0yUEBCcqFoAZOk47TwD3dPKS2WmRutke9StXnzsPBslY7prDM9w=="],
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.1", "", { "dependencies": { "debug": "^4.4.1" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA=="],
 
@@ -635,7 +635,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-svelte": ["lucide-svelte@0.542.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-KxqJycY4EWaGy1zk/7sqEcf48j4YaP9zEujYczzrsw5j9b9b5pjAJ1qGFKZvD7T6xz9reSYAfUAd6Bz62TdqGw=="],
+    "lucide-svelte": ["lucide-svelte@0.543.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-ri4LXrtoUtm08fED5ZER+MRavMOOscBGnVStoaY5w80uo7OOgt0w6eS4P4H3jtLicpa5RUV+chPwY4JdEHraAA=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
@@ -763,7 +763,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.38.7", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-1ld9TPZSdUS3EtYGQzisU2nhwXoIzNQcZ71IOU9fEmltaUofQnVfW5CQuhgM/zFsZ43arZXS1BRKi0MYgUV91w=="],
+    "svelte": ["svelte@5.38.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-UDpTbM/iuZ4MaMnn4ODB3rf5JKDyPOi5oJcopP0j7YHQ9BuJtsAqsR71r2N6AnJf7ygbalTJU5y8eSWGAQZjlQ=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^6.1.4",
+		"@sveltejs/vite-plugin-svelte": "^6.2.0",
 		"@umami/node": "^0.4.0",
 		"sparticles": "^1.3.1",
-		"svelte": "^5.38.7",
+		"svelte": "^5.38.8",
 		"vite": "^7.1.5"
 	},
 	"dependencies": {
@@ -18,7 +18,7 @@
 		"browserslist": "^4.25.4",
 		"fast-blurhash": "^1.1.4",
 		"lightningcss": "^1.30.1",
-		"lucide-svelte": "^0.542.0",
+		"lucide-svelte": "^0.543.0",
 		"path": "^0.12.7",
 		"vite-plugin-minify": "^2.1.0",
 		"vite-plugin-pwa": "^1.0.3"

--- a/src/lib/override.js
+++ b/src/lib/override.js
@@ -99,6 +99,18 @@ export const overrideOVGroup = {
 		[null, null, null, null, null],
 		[null, null, null, null, null],
 	],
+	/*"ZGY21K": [
+		[null, null, null, null, null],
+		[null, null, null, null, null],
+	],
+	"RGW1X6": [
+		[null, null, null, null, null],
+		[null, null, null, null, null],
+	],
+	"ZGW1WS": [
+		[null, null, null, null, null],
+		[null, null, null, null, null],
+	],*/
 	"ZGY21K": [
 		[null, null, null, "UW033", null],
 		[null, "UV02Z", null, null, null],
@@ -108,7 +120,7 @@ export const overrideOVGroup = {
 		[null, "UJ01Z", null, null, null],
 	],
 	"ZGW1WS": [
-		[null, null, null, "UY03L", null],
+		[null, null, null, "U0014", null],
 		[null, "UX03D", null, null, null],
 	],
 }


### PR DESCRIPTION
This pull request includes minor dependency updates and a small adjustment to override values in the `overrideOVGroup` object.

Dependency updates:

* Updated `@sveltejs/vite-plugin-svelte` to version `6.2.0`, `svelte` to `5.38.8`, and `lucide-svelte` to `0.543.0` in `package.json` to keep dependencies current.

Override value adjustment:

* Changed the override value for the fourth column in the first row of the `ZGW1WS` group from `"UY03L"` to `"U0014"` in `src/lib/override.js`.