### PR TITLE
another minor override fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@umami/node": "^0.4.0",
         "sparticles": "^1.3.1",
-        "svelte": "^5.39.5",
+        "svelte": "^5.39.6",
         "vite": "^7.1.7",
       },
     },
@@ -765,7 +765,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.39.5", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-YrTmQAgJNB5He5t14g+BH76xTjskcx0Dg3p6qKqfPcgha+9Rzdgkoazdk18ahzNfkFYgykZIjfnBvlPcp3NpYg=="],
+    "svelte": ["svelte@5.39.6", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-bOJXmuwLNaoqPCTWO8mPu/fwxI5peGE5Efe7oo6Cakpz/G60vsnVF6mxbGODaxMUFUKEnjm6XOwHEqOht6cbvw=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@umami/node": "^0.4.0",
 		"sparticles": "^1.3.1",
-		"svelte": "^5.39.5",
+		"svelte": "^5.39.6",
 		"vite": "^7.1.7"
 	},
 	"dependencies": {

--- a/src/lib/override.js
+++ b/src/lib/override.js
@@ -169,7 +169,7 @@ export const overrideRooms = {
 				["EM", "EM", "3", "VT1", "VT1", "VT2", "VT2", "EM", "EM"],
 				[null, "4", "4", "12", "2", "2", "2", "VT2", null],
 				[null, null, null, null, null, null, null, null, null], // OV
-				[null, "3", "3", "3", "3", "TV", "TV", null, null],
+				[null, "3", "11", "3", "3", "TV", "TV", null, null],
 			], // odd
 			[
 				[null, "4", "VT2", "VT2", "12", "12", "11", "11", null],


### PR DESCRIPTION
This pull request includes a minor dependency update and a small data correction. The most important changes are an upgrade to the `svelte` package and a fix to the room override data.

Dependency update:

* Upgraded the `svelte` dependency in `package.json` from version `^5.39.5` to `^5.39.6` to ensure the project uses the latest patch release.

Data correction:

* Updated the override room value in `src/lib/override.js` for the odd row, changing the value from `"3"` to `"11"` to correct the room assignment.