### PR TITLE
add early summer countdown background

### DIFF
--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -9,6 +9,7 @@
 	import { timetableCountdownStore, timetableFetch, timetablePermanentStore } from "../lib/timetable.js"
 	import { source, sourceGroupStore, sourceSchoolStore } from "../lib/var.js"
 	import { update } from "../main.js"
+    import Summer from "../components/season/Summer.svelte";
 
 	let time = $state(new Date())
 
@@ -78,10 +79,10 @@
 	{@const hourM = hour ? getM(hour["EndTime"]) : getM(hourNext?.["BeginTime"] ?? "00")}
 	{@const hourS = hour ? getS(hour["EndTime"]) : getS(hourNext?.["BeginTime"] ?? "00")}
 
-	<!--<Summer />-->
+	<Summer/>
 	<div id="countdown-block">
 		<div id="countdown-header">
-			<Banner />
+			<Banner/>
 		</div>
 		<!-- Days countdown
 		<div id="countdown-center">


### PR DESCRIPTION
This pull request updates the `Countdown.svelte` route to display the `Summer` component in the countdown view. The main change is the uncommenting and inclusion of the `Summer` seasonal component, which was previously not rendered.

Component inclusion:

* Imported the `Summer` component from `components/season/Summer.svelte` and rendered it in the `Countdown.svelte` route, making the seasonal UI visible to users. [[1]](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eR12) [[2]](diffhunk://#diff-aa09225e1f144ffaec8db30a6ae7c8c67e85ace9e072d222cff08eaeeb16fb0eL81-R82)